### PR TITLE
Update to PK-Sim 10

### DIFF
--- a/Erythromycin-Alfentanil-DDI.json
+++ b/Erythromycin-Alfentanil-DDI.json
@@ -43,7 +43,7 @@
         },
         {
           "Path": "ATP1A2|Reference concentration",
-          "Value": 0.47661714,
+          "Value": 0.39140774,
           "Unit": "µmol/l",
           "ValueOrigin": {
             "Source": "Unknown"
@@ -79,7 +79,7 @@
         },
         {
           "Path": "GABRG2|Reference concentration",
-          "Value": 1.0877710492,
+          "Value": 1.04099689,
           "Unit": "µmol/l",
           "ValueOrigin": {
             "Source": "Unknown"
@@ -1529,7 +1529,7 @@
             },
             {
               "Name": "kcat",
-              "Value": 2.0201069202,
+              "Value": 1.350032201,
               "Unit": "1/min",
               "ValueOrigin": {
                 "Source": "ParameterIdentification",

--- a/Erythromycin-Alfentanil-DDI.json
+++ b/Erythromycin-Alfentanil-DDI.json
@@ -1,5 +1,5 @@
 {
-  "Version": 77,
+  "Version": 78,
   "Individuals": [
     {
       "Name": "European (P-gp modified, CYP3A4 36 h)",
@@ -19,219 +19,522 @@
       },
       "Parameters": [
         {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|Relative expression in blood cells",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|Relative expression in plasma",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.47661714,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "GABRG2|Reference concentration",
+          "Value": 1.0877710492,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "GABRG2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "GABRG2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|AADAC|Relative expression",
+          "Value": 4.8717948718E-05
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0062154033171
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|P-gp|Relative expression",
+          "Value": 0.0242518189
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|AADAC|Relative expression",
+          "Value": 3.9743589744E-05
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ATP1A2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|GABRG2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00014166666667
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|P-gp|Relative expression",
+          "Value": 0.07608904
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|AADAC|Relative expression",
+          "Value": 0.0011923076923
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0508741242
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0141666667
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|P-gp|Relative expression",
+          "Value": 0.017417973
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|AADAC|Relative expression",
+          "Value": 0.0026602564103
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.3179118843
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0008253968254
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|P-gp|Relative expression",
+          "Value": 0.0419198106
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|AADAC|Relative expression",
+          "Value": 5.7051282051E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0158938619
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|P-gp|Relative expression",
+          "Value": 0.7092198582
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|P-gp|Relative expression",
+          "Value": 0.1108416465
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
           "Path": "Organism|Liver|EHC continuous fraction",
           "Value": 1.0,
           "ValueOrigin": {
             "Source": "Unknown"
           }
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|P-gp|Relative expression",
+          "Value": 0.1916810428
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|UGT1A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|P-gp|Relative expression",
+          "Value": 0.1916810428
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|UGT1A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|AADAC|Relative expression",
+          "Value": 0.0269230769
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0272345453
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|OATP1B1|Relative expression",
+          "Value": 4.0079365079E-05
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|P-gp|Relative expression",
+          "Value": 0.0657549316
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|AADAC|Relative expression",
+          "Value": 0.00020833333333
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.7034193524
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00064682539683
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|P-gp|Relative expression",
+          "Value": 0.0128342959
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|AADAC|Relative expression",
+          "Value": 0.1474358974
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0073903254795
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|P-gp|Relative expression",
+          "Value": 0.0142510689
+        },
+        {
+          "Path": "Organism|Skin|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0389467988
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|P-gp|Relative expression",
+          "Value": 0.2808543974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|AADAC|Relative expression",
+          "Value": 0.00037115384615
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0103243118
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|P-gp|Relative expression",
+          "Value": 0.0742555691
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|AADAC|Relative expression",
+          "Value": 0.0775641026
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0309435884
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|P-gp|Relative expression",
+          "Value": 0.0260852897
+        },
+        {
+          "Path": "P-gp|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "P-gp|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "P-gp|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "UGT1A4|Reference concentration",
+          "Value": 2.32,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "UGT1A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "UGT1A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
         }
       ],
       "Molecules": [
         {
           "Name": "CYP3A4",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Brain",
-              "Value": 0.0041682898325
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.00078691079081
-            },
-            {
-              "Name": "Kidney",
-              "Value": 0.0053603428126
-            },
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.00042695753798
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.0727697702
-            }
-          ],
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
           "Ontogeny": {
             "Name": "CYP3A4"
-          },
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 4.32,
-              "Unit": "µmol/l"
-            },
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            },
-            {
-              "Name": "t1/2 (intestine)",
-              "Value": 23.0,
-              "Unit": "h"
-            }
-          ]
+          }
         },
         {
           "Name": "AADAC",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "BloodCells",
-              "Value": 3.9102564103E-05
-            },
-            {
-              "Name": "Plasma",
-              "Value": 3.9102564103E-05
-            },
-            {
-              "Name": "Bone",
-              "Value": 4.8717948718E-05
-            },
-            {
-              "Name": "Brain",
-              "Value": 3.9743589744E-05
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.0011923076923
-            },
-            {
-              "Name": "Heart",
-              "Value": 0.0026602564103
-            },
-            {
-              "Name": "Kidney",
-              "Value": 5.7051282051E-05
-            },
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.0269230769
-            },
-            {
-              "Name": "Muscle",
-              "Value": 0.00020833333333
-            },
-            {
-              "Name": "Pancreas",
-              "Value": 0.1474358974
-            },
-            {
-              "Name": "Spleen",
-              "Value": 0.00037115384615
-            },
-            {
-              "Name": "Stomach",
-              "Value": 0.0775641026
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LargeIntestine",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "ColonAscendens",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonTransversum",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonDescendens",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonSigmoid",
-              "Value": 0.00010384615385
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.0,
-              "Unit": "µmol/l"
-            },
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h"
-            },
-            {
-              "Name": "t1/2 (intestine)",
-              "Value": 23.0,
-              "Unit": "h"
-            }
-          ]
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
         },
         {
           "Name": "P-gp",
@@ -240,118 +543,221 @@
           "Expression": [
             {
               "Name": "Bone",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0341950646
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Brain",
-              "MembraneLocation": "BloodBrainBarrier",
-              "Value": 0.1072855464
+              "TransportDirection": "EffluxBrainInterstitialToPlasma",
+              "CompartmentName": "Plasma"
+            },
+            {
+              "Name": "Brain",
+              "TransportDirection": "EffluxBrainTissueToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Fat",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Gonads",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.024559342
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Heart",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.059106933
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Kidney",
-              "MembraneLocation": "Apical",
-              "Value": 1.0
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
             },
             {
-              "Name": "Periportal",
-              "MembraneLocation": "Apical",
-              "Value": 0.2702702703
-            },
-            {
-              "Name": "Pericentral",
-              "MembraneLocation": "Apical",
-              "Value": 0.2702702703
-            },
-            {
-              "Name": "Lung",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0927144536
-            },
-            {
-              "Name": "Muscle",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0180963572
-            },
-            {
-              "Name": "Pancreas",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0200940071
-            },
-            {
-              "Name": "Spleen",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.1047003525
+              "Name": "Kidney",
+              "TransportDirection": "ExcretionKidney",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Stomach",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0367802585
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "SmallIntestine",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.3960047004
-            },
-            {
-              "Name": "LargeIntestine",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.1562867215
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Duodenum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "UpperJejunum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "LowerJejunum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "UpperIleum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "LowerIleum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LargeIntestine",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonAscendens",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonTransversum",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonDescendens",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonSigmoid",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Lung",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Muscle",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pancreas",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Skin",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Spleen",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "BloodCells",
+              "TransportDirection": "EffluxBloodCellsToPlasma"
+            },
+            {
+              "Name": "VascularEndothelium",
+              "TransportDirection": "EffluxInterstitialToPlasma"
             }
           ],
           "Ontogeny": {
@@ -610,27 +1016,7 @@
                 }
               ]
             }
-          },
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.41,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            },
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h"
-            },
-            {
-              "Name": "t1/2 (intestine)",
-              "Value": 23.0,
-              "Unit": "h"
-            }
-          ]
+          }
         },
         {
           "Name": "OATP1B1",
@@ -638,256 +1024,242 @@
           "TransportType": "Influx",
           "Expression": [
             {
+              "Name": "Bone",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
               "Name": "Brain",
-              "MembraneLocation": "BloodBrainBarrier",
-              "Value": 0.00014166666667
+              "TransportDirection": "InfluxBrainPlasmaToInterstitial",
+              "CompartmentName": "Plasma"
+            },
+            {
+              "Name": "Brain",
+              "TransportDirection": "InfluxBrainInterstitialToTissue",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Fat",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Gonads",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0141666667
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Heart",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0008253968254
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Kidney",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Kidney",
+              "TransportDirection": "ExcretionKidney",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Stomach",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "SmallIntestine",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LargeIntestine",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Periportal",
-              "MembraneLocation": "Basolateral",
-              "Value": 1.0
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Pericentral",
-              "MembraneLocation": "Basolateral",
-              "Value": 1.0
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Lung",
-              "MembraneLocation": "Basolateral",
-              "Value": 4.0079365079E-05
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Muscle",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.00064682539683
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.0,
-              "Unit": "µmol/l"
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h"
+              "Name": "Pancreas",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
-              "Name": "t1/2 (intestine)",
-              "Value": 23.0,
-              "Unit": "h"
+              "Name": "Skin",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Spleen",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "BloodCells",
+              "TransportDirection": "InfluxPlasmaToBloodCells"
+            },
+            {
+              "Name": "VascularEndothelium",
+              "TransportDirection": "InfluxPlasmaToInterstitial"
             }
           ]
         },
         {
           "Name": "ATP1A2",
           "Type": "OtherProtein",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "ExtracellularMembrane",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Bone",
-              "Value": 0.0062154033171
-            },
-            {
-              "Name": "Brain",
-              "Value": 1.0
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.0508741242
-            },
-            {
-              "Name": "Heart",
-              "Value": 0.3179118843
-            },
-            {
-              "Name": "Kidney",
-              "Value": 0.0158938619
-            },
-            {
-              "Name": "Periportal",
-              "Value": 0.0223784807
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 0.0223784807
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.0272345453
-            },
-            {
-              "Name": "Muscle",
-              "Value": 0.7034193524
-            },
-            {
-              "Name": "Pancreas",
-              "Value": 0.0073903254795
-            },
-            {
-              "Name": "Skin",
-              "Value": 0.0389467988
-            },
-            {
-              "Name": "Spleen",
-              "Value": 0.0103243118
-            },
-            {
-              "Name": "Stomach",
-              "Value": 0.0309435884
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LargeIntestine",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "ColonAscendens",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonTransversum",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonDescendens",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonSigmoid",
-              "Value": 0.0786998764
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 0.47661714,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            },
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h"
-            },
-            {
-              "Name": "t1/2 (intestine)",
-              "Value": 23.0,
-              "Unit": "h"
-            }
-          ]
+          "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
         },
         {
           "Name": "UGT1A4",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            }
-          ],
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
           "Ontogeny": {
             "Name": "UGT1A4"
-          },
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 2.32,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            },
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h"
-            },
-            {
-              "Name": "t1/2 (intestine)",
-              "Value": 23.0,
-              "Unit": "h"
-            }
-          ]
+          }
         },
         {
           "Name": "GABRG2",
           "Type": "OtherProtein",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "ExtracellularMembrane",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Brain",
-              "Value": 1.0
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.0877710492,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            },
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h"
-            },
-            {
-              "Name": "t1/2 (intestine)",
-              "Value": 23.0,
-              "Unit": "h"
-            }
-          ]
+          "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
         }
       ]
     }
@@ -1474,6 +1846,15 @@
               "ValueOrigin": {
                 "Source": "Unknown"
               }
+            },
+            {
+              "Name": "NumberOfRepetitions",
+              "Value": 1.0
+            },
+            {
+              "Name": "TimeBetweenRepetitions",
+              "Value": 0.0,
+              "Unit": "h"
             }
           ]
         }
@@ -1517,6 +1898,15 @@
               "ValueOrigin": {
                 "Source": "Unknown"
               }
+            },
+            {
+              "Name": "NumberOfRepetitions",
+              "Value": 1.0
+            },
+            {
+              "Name": "TimeBetweenRepetitions",
+              "Value": 0.0,
+              "Unit": "h"
             }
           ]
         }
@@ -1577,6 +1967,11 @@
           ],
           "Parameters": [
             {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
               "Name": "NumberOfRepetitions",
               "Value": 14.0,
               "ValueOrigin": {
@@ -1627,6 +2022,11 @@
             }
           ],
           "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
             {
               "Name": "NumberOfRepetitions",
               "Value": 13.0,
@@ -1924,6 +2324,21 @@
           "Path": "Applications|PO_Erythromycin_Day7|Erythromycin_Weibull_enteric-coated-tablet|Application_9|ProtocolSchemaItem|Volume of water/body weight",
           "Value": 3.5,
           "Unit": "ml/kg"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
         }
       ],
       "OutputSelections": [
@@ -2152,6 +2567,21 @@
           "Path": "Applications|PO_Erythromycin_Day1|Erythromycin_Weibull_enteric-coated-tablet|Application_1|ProtocolSchemaItem|Volume of water/body weight",
           "Value": 3.5,
           "Unit": "ml/kg"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
         }
       ],
       "OutputSelections": [
@@ -2399,22 +2829,22 @@
             "MolWeight": 416.52
           },
           "Values": [
-            274.796326,
-            203.0085,
-            145.2516,
-            107.3704,
-            65.60405,
-            47.0218,
-            38.90292,
-            17.8707,
-            12.83194,
-            8.6443,
-            5.207983,
-            3.344742,
-            2.326359
+            0.2747963,
+            0.2030085,
+            0.1452516,
+            0.1073704,
+            0.065604046,
+            0.0470218,
+            0.03890292,
+            0.0178707,
+            0.01283194,
+            0.00864430051,
+            0.005207983,
+            0.003344742,
+            0.002326359
           ],
           "Dimension": "Concentration (mass)",
-          "Unit": "µg/l"
+          "Unit": "mg/l"
         }
       ],
       "BaseGrid": {
@@ -2538,22 +2968,22 @@
             "MolWeight": 416.52
           },
           "Values": [
-            339.0593,
-            179.4489,
-            160.5851,
-            126.663193,
-            67.21241,
-            48.24575,
-            36.33242,
-            19.0285,
-            17.39914,
-            10.85528,
-            8.728917,
-            6.701466,
-            6.123849
+            0.3390593,
+            0.1794489,
+            0.1605851,
+            0.1266632,
+            0.06721241,
+            0.04824575,
+            0.03633242,
+            0.0190285,
+            0.01739914,
+            0.01085528,
+            0.008728917,
+            0.006701466,
+            0.006123849
           ],
           "Dimension": "Concentration (mass)",
-          "Unit": "µg/l"
+          "Unit": "mg/l"
         }
       ],
       "BaseGrid": {
@@ -2677,22 +3107,22 @@
             "MolWeight": 416.52
           },
           "Values": [
-            348.6219,
-            279.7591,
-            201.1031,
-            144.6463,
-            114.4426,
-            94.9309,
-            60.2614059,
-            47.0248,
-            41.6181,
-            42.44977,
-            27.85588,
-            26.67941,
-            18.64286
+            0.348621875,
+            0.279759079,
+            0.2011031,
+            0.1446463,
+            0.1144426,
+            0.0949309,
+            0.060261406,
+            0.0470247976,
+            0.0416181,
+            0.0424497724,
+            0.02785588,
+            0.0266794115,
+            0.01864286
           ],
           "Dimension": "Concentration (mass)",
-          "Unit": "µg/l"
+          "Unit": "mg/l"
         }
       ],
       "BaseGrid": {
@@ -2816,19 +3246,19 @@
             "MolWeight": 416.52
           },
           "Values": [
-            120.190491,
-            74.53243,
-            43.75653,
-            35.6713,
-            20.39494,
-            14.50891,
-            10.18339,
-            6.859829,
-            3.976759,
-            2.536557
+            0.120190494,
+            0.07453243,
+            0.04375653,
+            0.0356712975,
+            0.02039494,
+            0.0145089105,
+            0.0101833893,
+            0.006859829,
+            0.003976759,
+            0.002536557
           ],
           "Dimension": "Concentration (mass)",
-          "Unit": "µg/l"
+          "Unit": "mg/l"
         }
       ],
       "BaseGrid": {
@@ -2949,20 +3379,20 @@
             "MolWeight": 416.52
           },
           "Values": [
-            207.6484,
-            121.849991,
-            74.53243,
-            46.85556,
-            38.72251,
-            29.91228,
-            29.55565,
-            28.80557,
-            18.88248,
-            13.07345,
-            9.560584
+            0.207648411,
+            0.121849991,
+            0.07453243,
+            0.04685556,
+            0.03872251,
+            0.0299122781,
+            0.02955565,
+            0.02880557,
+            0.0188824814,
+            0.01307345,
+            0.009560584
           ],
           "Dimension": "Concentration (mass)",
-          "Unit": "µg/l"
+          "Unit": "mg/l"
         }
       ],
       "BaseGrid": {
@@ -3084,19 +3514,19 @@
             "MolWeight": 416.52
           },
           "Values": [
-            326.0096,
-            241.358612,
-            176.2952,
-            117.0552,
-            90.34785,
-            47.62191,
-            32.07951,
-            23.14172,
-            16.69467,
-            16.95203
+            0.326009631,
+            0.241358608,
+            0.1762952,
+            0.1170552,
+            0.09034785,
+            0.04762191,
+            0.03207951,
+            0.02314172,
+            0.01669467,
+            0.01695203
           ],
           "Dimension": "Concentration (mass)",
-          "Unit": "µg/l"
+          "Unit": "mg/l"
         }
       ],
       "BaseGrid": {


### PR DESCRIPTION
Update to PK-Sim 10 including update of GABRG2 and ATP1A2 reference concentrations and OATP1B1 kcat value to account for pk-sim 10 update in interstitial concentration calculations.